### PR TITLE
Svgs and store relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.1.1
+
+* Fixes a bug caused by picking an SVG from the media library. Favicons can now be generated from SVGs
+
+* Fixes a bug where favicon processing was running more than neccessary. This was specifically seen when using in conjunction with `apostrophe-workflow` (and potentially `apostrophe-palette`). Now we store the last good image relationship as a string on the global doc for more consistent comparison.
+
 ## 1.1.0
 
 * Progress is now displayed via the new server-side support for `apos.notify` in Apostrophe. Note that Apostrophe must be at least version 2.73.0.

--- a/lib/modules/apostrophe-favicons-global/index.js
+++ b/lib/modules/apostrophe-favicons-global/index.js
@@ -2,7 +2,6 @@ const _ = require('lodash');
 const favicons = require('favicons');
 const async = require('async');
 const fs = require('fs-extra');
-const svg2png = require('svg-to-png');
 
 module.exports = {
   improve: 'apostrophe-global',

--- a/lib/modules/apostrophe-favicons-global/index.js
+++ b/lib/modules/apostrophe-favicons-global/index.js
@@ -21,19 +21,6 @@ module.exports = {
           minSize: [ 500, 500 ],
           limit: [ 1 ]
         }
-      },
-      {
-        name: 'aposFaviconLinks',
-        label: 'Favicon Link Tags',
-        type: 'string',
-        contextual: true,
-      },
-      {
-        name: 'aposFaviconRelationship',
-        label: 'Favicon Image Relationship',
-        help: 'Internal flag for identifying when a change has been made to the favicon selection / crop',
-        type: 'string',
-        contextual: true,
       }
     ];
 
@@ -131,6 +118,10 @@ the global preferences are saved.`,
 
         if (piece.aposFavicon && piece.aposFavicon.items.length) {
           compare = JSON.stringify(piece.aposFavicon.items[0].relationships);
+        } else {
+          // no image or image was deleted from field
+          // clear out processed fields
+          return saveFields({ html: [] }, null);
         }
 
         if (compare !== piece.aposFaviconRelationship) {
@@ -195,12 +186,16 @@ the global preferences are saved.`,
                 }
               }
             });
-            const sizeExtension = size ? (size.name + '.') : '';
 
-            let originalPath = '/attachments/' + image.attachment._id + '-' + image.attachment.name + '.' + sizeExtension + image.attachment.extension;
+            let originalPath = attachments.url(image.attachment, {
+              uploadfsPath: true,
+              size: size.name
+            });
 
             if (image.attachment.extension === 'svg') {
-              originalPath = '/attachments/' + image.attachment._id + '-' + image.attachment.name + '.' + image.attachment.extension;
+              originalPath = attachments.url(image.attachment, {
+                uploadfsPath: true
+              });
             }
 
             let tempPath = attachments.uploadfs.getTempPath() + '/' + self.apos.utils.generateId() + '.' + image.attachment.extension;
@@ -263,6 +258,7 @@ the global preferences are saved.`,
           } else {
             relationship = 'undefined'
           }
+
           return self.apos.docs.db.update({ _id: piece._id }, { $set: {
             aposFaviconLinks: response.html.join(''),
             aposFaviconRelationship: relationship

--- a/lib/modules/apostrophe-favicons-global/index.js
+++ b/lib/modules/apostrophe-favicons-global/index.js
@@ -2,6 +2,7 @@ const _ = require('lodash');
 const favicons = require('favicons');
 const async = require('async');
 const fs = require('fs-extra');
+const svg2png = require('svg-to-png');
 
 module.exports = {
   improve: 'apostrophe-global',
@@ -25,6 +26,13 @@ module.exports = {
       {
         name: 'aposFaviconLinks',
         label: 'Favicon Link Tags',
+        type: 'string',
+        contextual: true,
+      },
+      {
+        name: 'aposFaviconRelationship',
+        label: 'Favicon Image Relationship',
+        help: 'Internal flag for identifying when a change has been made to the favicon selection / crop',
         type: 'string',
         contextual: true,
       }
@@ -65,22 +73,13 @@ module.exports = {
 
     self.pushAsset('script', 'user', { when: 'user' });
 
-    // Before save, make a note of our favicon field so that we can see if it changed later
-    const superConvert = self.convert;
-    self.convert = function (req, piece, callback) {
-      if (piece.aposFavicon && piece.aposFavicon.items.length) {
-        piece._originalFaviconRelationship = piece.aposFavicon.items[0].relationships
-      }
-      return superConvert(req, piece, callback);
-    };
-
     // Check on changes made to the favicon widget in afterSave
     const superAfterSave = self.afterSave;
     self.afterSave = function (req, piece, options, callback) {
-      
+
       // This intentionally returns control to the browser while the module crunches on a potentially
       // long resizing process. We will monitor the progress on the front-end by hitting a status route
-      
+
       superAfterSave(req, piece, options, callback);
 
       // Exec the real work as a child process because otherwise
@@ -132,31 +131,28 @@ the global preferences are saved.`,
       function body(callback) {
 
         if (piece.aposFavicon && piece.aposFavicon.items.length) {
-          compare = piece.aposFavicon.items[0].relationships;
+          compare = JSON.stringify(piece.aposFavicon.items[0].relationships);
         }
 
-        if (piece.aposFavicon.items.length !== 0 && ((piece._originalFaviconRelationship && JSON.stringify(piece._originalFaviconRelationship) !== JSON.stringify(compare) && piece.aposFavicon.items[0] !== undefined) || piece._originalFaviconRelationship === undefined)) {
-
+        if (compare !== piece.aposFaviconRelationship) {
           apos.notify(argv['notify-user-id'], 'Processing favicon files...');
-
-          // Set in motion the actual work of creating the favicons
           return async.waterfall([
             cleanup,
             getImage,
             generateFavicons,
             copyToUploadfs,
-            saveLinks,
-            function(result, callback) {
+            saveFields,
+            function (result, callback) {
               return cleanup(callback);
             }
-          ], function(err) {
+          ], function (err) {
             if (err) {
+              apos.utils.error(err);
               apos.notify(argv['notify-user-id'], 'An error occurred processing the favicon files.', callback);
             } else {
               apos.notify(argv['notify-user-id'], 'Favicon processing complete.', callback);
             }
           });
-
         } else {
           // If we made it here there was no change to our target field, carry on
           return callback(null);
@@ -201,9 +197,14 @@ the global preferences are saved.`,
               }
             });
             const sizeExtension = size ? (size.name + '.') : '';
-            let originalPath = '/attachments/' + image.attachment._id + '-' + image.attachment.name + '.' + sizeExtension + image.attachment.extension;
-            let tempPath = attachments.uploadfs.getTempPath() + '/' + self.apos.utils.generateId() + '.' + image.attachment.extension;
 
+            let originalPath = '/attachments/' + image.attachment._id + '-' + image.attachment.name + '.' + sizeExtension + image.attachment.extension;
+
+            if (image.attachment.extension === 'svg') {
+              originalPath = '/attachments/' + image.attachment._id + '-' + image.attachment.name + '.' + image.attachment.extension;
+            }
+
+            let tempPath = attachments.uploadfs.getTempPath() + '/' + self.apos.utils.generateId() + '.' + image.attachment.extension;
             return attachments.uploadfs.copyOut(originalPath, tempPath, function(err) {
               if (err) {
                 return callback(err);
@@ -256,9 +257,17 @@ the global preferences are saved.`,
         };
 
         // Save the generated tag markup to the global doc
-        function saveLinks(response, callback) {
-          piece.aposFaviconLinks = response.html.join('');
-          return self.apos.docs.db.update({ _id: piece._id }, { $set: { aposFaviconLinks: response.html.join('') } }, callback);
+        function saveFields(response, callback) {
+          let relationship;
+          if (piece.aposFavicon.items[0]) {
+            relationship = JSON.stringify(piece.aposFavicon.items[0].relationships)
+          } else {
+            relationship = 'undefined'
+          }
+          return self.apos.docs.db.update({ _id: piece._id }, { $set: {
+            aposFaviconLinks: response.html.join(''),
+            aposFaviconRelationship: relationship
+          } }, callback);
         }
       }
     });

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "core-js": "*",
     "favicons": "^5.1.1",
     "fs-extra": "^6.0.1",
-    "lodash": "^4.17.10"
+    "lodash": "^4.17.10",
+    "svg-to-png": "^4.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "core-js": "*",
     "favicons": "^5.1.1",
     "fs-extra": "^6.0.1",
-    "lodash": "^4.17.10",
-    "svg-to-png": "^4.0.0"
+    "lodash": "^4.17.10"
   }
 }


### PR DESCRIPTION
* Fixes a bug caused by picking an SVG from the media library. Favicons can now be generated from SVGs

* Fixes a bug where favicon processing was running more than necessary. This was specifically seen when using in conjunction with `apostrophe-workflow` (and potentially `apostrophe-palette`). Now we store the last good image relationship as a string on the global doc for more consistent comparison.